### PR TITLE
Update limit values

### DIFF
--- a/src/database/migrations/20180824115638_deployment_constraint_seed.js
+++ b/src/database/migrations/20180824115638_deployment_constraint_seed.js
@@ -72,8 +72,8 @@ exports.up = function(knex) {
           }
         },
         "pgbouncer": {
-          "metadataPoolSize": 2,
-          "resultBackendPoolSize": 1,
+          "metadataPoolSize": 3,
+          "resultBackendPoolSize": 2,
           "resources": {
             "limits": {
               "cpu": "500m",
@@ -190,8 +190,8 @@ exports.up = function(knex) {
           }
         },
         "pgbouncer": {
-          "metadataPoolSize": 2,
-          "resultBackendPoolSize": 1,
+          "metadataPoolSize": 3,
+          "resultBackendPoolSize": 2,
           "resources": {
             "limits": {
               "cpu": "500m",

--- a/src/database/migrations/20180824115638_deployment_constraint_seed.js
+++ b/src/database/migrations/20180824115638_deployment_constraint_seed.js
@@ -12,8 +12,8 @@ exports.up = function(knex) {
         "workers": {
           "resources": {
             "limits": {
-              "cpu": "4",
-              "memory": "8192Mi"
+              "cpu": "2",
+              "memory": "6Gi"
             },
             "requests": {
               "cpu": "500m",
@@ -101,14 +101,14 @@ exports.up = function(knex) {
           "pods": 100,
           "requests.cpu": "3000m",
           "requests.memory": "12Gi",
-          "limits.cpu": "5000m",
-          "limits.memory": "20Gi"
+          "limits.cpu": "10000m",
+          "limits.memory": "30Gi"
         },
         "limits": [{
           "type": "Pod",
           "max": {
             "cpu": "4",
-            "memory": "8192Mi"
+            "memory": "8Gi"
           }
         }, {
           "type": "Container",
@@ -130,8 +130,8 @@ exports.up = function(knex) {
         "workers": {
           "resources": {
             "limits": {
-              "cpu": "4",
-              "memory": "8192Mi"
+              "cpu": "2",
+              "memory": "6Gi"
             },
             "requests": {
               "cpu": "500m",
@@ -220,15 +220,15 @@ exports.up = function(knex) {
             "pods": 100,
             "requests.cpu": "3000m",
             "requests.memory": "12Gi",
-            "limits.cpu": "5000m",
-            "limits.memory": "20Gi"
+            "limits.cpu": "10000m",
+            "limits.memory": "30Gi"
           },
         },
         "limits": [{
           "type": "Pod",
           "max": {
             "cpu": "4",
-            "memory": "8192Mi"
+            "memory": "8Gi"
           }
         }, {
           "type": "Container",


### PR DESCRIPTION
This updates some of the default limit values that we were hitting during new airflow deployments.

1. Lower default worker limit to 2 cores
2. Raise limitrange and quota to support up to 3 workers for now.
3. Update pgbouncer pool sizes