### PR TITLE
Bump quotas

### DIFF
--- a/src/database/migrations/20180824115638_deployment_constraint_seed.js
+++ b/src/database/migrations/20180824115638_deployment_constraint_seed.js
@@ -99,10 +99,10 @@ exports.up = function(knex) {
         },
         "quotas": {
           "pods": 100,
-          "requests.cpu": "3000m",
-          "requests.memory": "12Gi",
-          "limits.cpu": "10000m",
-          "limits.memory": "30Gi"
+          "requests.cpu": "4000m",
+          "requests.memory": "16Gi",
+          "limits.cpu": "16000m",
+          "limits.memory": "64Gi"
         },
         "limits": [{
           "type": "Pod",
@@ -216,13 +216,11 @@ exports.up = function(knex) {
           }
         },
         "quotas": {
-          "quotas": {
-            "pods": 100,
-            "requests.cpu": "3000m",
-            "requests.memory": "12Gi",
-            "limits.cpu": "10000m",
-            "limits.memory": "30Gi"
-          },
+          "pods": 100,
+          "requests.cpu": "4000m",
+          "requests.memory": "16Gi",
+          "limits.cpu": "16000m",
+          "limits.memory": "64Gi"
         },
         "limits": [{
           "type": "Pod",


### PR DESCRIPTION
Bump quotas up to allow for more workers and deal with surges during rolling updates. These values shouldn't be hit, but help put a cap on things for supporting the pod operator. 